### PR TITLE
[INTERNAL] Integrate fork changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ This action uses the Netlify API to always retrieve the correct deployment being
 
 **Required** The API ID of your site. See Settings > Site Details > General in the Netlify UI
 
-### `max_timeout`
+### `deploy_timeout`
+
+Optional — The amount of time to spend waiting on the Netlify deployment to respond with a "ready" status. Defaults to 300 seconds.
+
+### `readiness_timeout`
+
+Optional — The amount of time to spend waiting on the Netlify deployment to respond with a "ready" status. Defaults to 900 seconds.
+
+### `response_timeout`
 
 Optional — The amount of time to spend waiting on the Netlify deployment to respond with a success HTTP code after reaching "ready" status. Defaults to 60 seconds.
 
@@ -43,7 +51,7 @@ steps:
       site_id: 'YOUR_SITE_ID' # See Settings > Site Details > General in the Netlify UI
     env:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-      
+
 # Then use it in a later step like:
 # ${{ steps.waitForDeployment.outputs.url }}
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action uses the Netlify API to always retrieve the correct deployment being
 
 ### `deploy_timeout`
 
-Optional — The amount of time to spend waiting on the Netlify deployment to respond with a "ready" status. Defaults to 300 seconds.
+Optional — The amount of time to spend waiting on the Netlify deployment to complete the build phase. Defaults to 300 seconds.
 
 ### `readiness_timeout`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Optional — The amount of time to spend waiting on the Netlify deployment to re
 
 Optional — The amount of time to spend waiting on the Netlify deployment to respond with a success HTTP code after reaching "ready" status. Defaults to 60 seconds.
 
+### `context`
+
+Optional — The Netlify deploy context. Can be `branch-deploy`, `production` or `deploy-preview`. Defaults to all of them.
+
 ## Outputs
 
 ### `url`

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,14 @@ inputs:
   site_id:
     description: "The Netlify site ID to test against, get this from the Netlify UI under site settings."
     required: true
-  max_timeout:
-    description: "The max time to wait after the deployment is ready for a valid HTTP status code."
+  deploy_timeout:
+    description: "The amount of time to spend waiting on the Netlify deployment to complete the build phase. Defaults to 300 seconds."
+    required: false
+  readiness_timeout:
+    description: "The amount of time to spend waiting on the Netlify deployment to respond with a \"ready\" status. Defaults to 900 seconds."
+    required: false
+  response_timeout:
+    description: "The amount of time to spend waiting on the Netlify deployment to respond with a success HTTP code after reaching \"ready\" status. Defaults to 60 seconds."
     required: false
 outputs:
   deploy_id:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   response_timeout:
     description: "The amount of time to spend waiting on the Netlify deployment to respond with a success HTTP code after reaching \"ready\" status. Defaults to 60 seconds."
     required: false
+  context:
+    description: "The Netlify deploy context. Can be branch-deploy, production or deploy-preview."
+    required: false
 outputs:
   deploy_id:
     description: "The Netlify deployment ID"

--- a/index.js
+++ b/index.js
@@ -94,9 +94,11 @@ const run = async () => {
     const netlifyToken = process.env.NETLIFY_TOKEN;
     const commitSha =
       github.context.eventName === 'pull_request' ? github.context.payload.pull_request.head.sha : github.context.sha;
-    const MAX_CREATE_TIMEOUT = 60 * 5; // 5 min
-    const MAX_WAIT_TIMEOUT = 60 * 15; // 15 min
-    const MAX_READY_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
+
+    const DEPLOY_TIMEOUT = Number(core.getInput('deploy_timeout')) || 60 * 5;
+    const READINESS_TIMEOUT = Number(core.getInput('readiness_timeout')) || 60 * 15;
+    // keep max_timeout for backwards compatibility
+    const RESPONSE_TIMEOUT = Number(core.getInput('response_timeout')) || Number(core.getInput('max_timeout')) || 60;
     const siteId = core.getInput('site_id');
 
     if (!netlifyToken) {
@@ -113,7 +115,7 @@ const run = async () => {
     const commitDeployment = await waitForDeployCreation(
       `https://api.netlify.com/api/v1/sites/${siteId}/deploys`,
       commitSha,
-      MAX_CREATE_TIMEOUT
+      DEPLOY_TIMEOUT
     );
 
     const url = `https://${commitDeployment.id}--${commitDeployment.name}.netlify.app`;
@@ -124,11 +126,11 @@ const run = async () => {
     console.log(`Waiting for Netlify deployment ${commitDeployment.id} in site ${commitDeployment.name} to be ready`);
     await waitForReadiness(
       `https://api.netlify.com/api/v1/sites/${siteId}/deploys/${commitDeployment.id}`,
-      MAX_WAIT_TIMEOUT
+      READINESS_TIMEOUT
     );
 
     console.log(`Waiting for a 200 from: ${url}`);
-    await waitForUrl(url, MAX_READY_TIMEOUT);
+    await waitForUrl(url, RESPONSE_TIMEOUT);
   } catch (error) {
     core.setFailed(typeof error === 'string' ? error : error.message);
   }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function getNetlifyUrl(url) {
   });
 }
 
-const waitForDeployCreation = (url, commitSha, MAX_TIMEOUT) => {
+const waitForDeployCreation = (url, commitSha, MAX_TIMEOUT, context) => {
   const increment = 15;
 
   return new Promise((resolve, reject) => {
@@ -32,7 +32,7 @@ const waitForDeployCreation = (url, commitSha, MAX_TIMEOUT) => {
         return reject(`Failed to get deployments for site`);
       }
 
-      const commitDeployment = netlifyDeployments.find((d) => d.commit_ref === commitSha);
+      const commitDeployment = netlifyDeployments.find((d) => d.commit_ref === commitSha && (!context || d.context === context));
 
       if (commitDeployment) {
         clearInterval(handle);
@@ -100,6 +100,7 @@ const run = async () => {
     // keep max_timeout for backwards compatibility
     const RESPONSE_TIMEOUT = Number(core.getInput('response_timeout')) || Number(core.getInput('max_timeout')) || 60;
     const siteId = core.getInput('site_id');
+    const context = core.getInput('context');
 
     if (!netlifyToken) {
       core.setFailed('Please set NETLIFY_TOKEN env variable to your Netlify Personal Access Token secret');
@@ -111,11 +112,18 @@ const run = async () => {
       core.setFailed('Required field `site_id` was not provided');
     }
 
-    console.log(`Waiting for Netlify to create a deployment for git SHA ${commitSha}`);
+    let message = `Waiting for Netlify to create a deployment for git SHA ${commitSha}`;
+
+    if (context) {
+      message += ` and context ${context}`
+    }
+
+    console.log(message);
     const commitDeployment = await waitForDeployCreation(
       `https://api.netlify.com/api/v1/sites/${siteId}/deploys`,
       commitSha,
-      DEPLOY_TIMEOUT
+      DEPLOY_TIMEOUT,
+      context
     );
 
     const url = `https://${commitDeployment.id}--${commitDeployment.name}.netlify.app`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-netlify-action",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "A GitHub action that waits for a Netlify deployment preview for the current commit being built",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-netlify-action",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A GitHub action that waits for a Netlify deployment preview for the current commit being built",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Overview

Brings in changes from downstream forks of `probablyup/wait-for-netlify-action`:

* https://github.com/hharnisc/wait-for-netlify-action
    * Add fine-grained timeout controls (`deploy_timeout`, `readiness_timeout`, `response_timeout`) - [commit](https://github.com/hharnisc/wait-for-netlify-action/commit/b1ece10766912e17b9c67372e8eab5a9aaa17e77), [commit](https://github.com/hharnisc/wait-for-netlify-action/commit/f9aecdc2dcc9d7171b63f6d7c478b927822a741d) 

* https://github.com/dnsv/wait-for-netlify-action
    * Add a `context` option to filter commits - [commit](https://github.com/dnsv/wait-for-netlify-action/commit/12bc36f23911a785cccad56e9be6757d5b332bcc)

