### PR TITLE
[FEATURE] Support skipped builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ Optional — The Netlify deploy context. Can be `branch-deploy`, `production` or
 
 ## Outputs
 
-### `url`
-
-The Netlify deploy preview url that was deployed.
-
 ### `deploy_id`
 
 The Netlify deployment ID that was deployed.
+
+### `skipped`
+
+If the build was skipped. Will be set to the 'true' if skipped and 'false' if build succeeded.
+
+### `url`
+
+The Netlify deploy preview url that was deployed.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ inputs:
 outputs:
   deploy_id:
     description: "The Netlify deployment ID"
+  skipped:
+    description: "If the build was skipped. Will be set to 'true' if skipped."
   url:
     description: "The fully qualified deployment URL"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ outputs:
   deploy_id:
     description: "The Netlify deployment ID"
   skipped:
-    description: "If the build was skipped. Will be set to 'true' if skipped."
+    description: "If the build was skipped. Will be set to 'true' if skipped and 'false' if build succeeded."
   url:
     description: "The fully qualified deployment URL"
 runs:

--- a/src/run/run.js
+++ b/src/run/run.js
@@ -57,13 +57,18 @@ const run = async () => {
     console.log(
       `Waiting for Netlify deployment ${commitDeployment.id} in site ${commitDeployment.name} to be ready`,
     )
-    await waitForReadiness(
+    const state = await waitForReadiness(
       `https://api.netlify.com/api/v1/sites/${siteId}/deploys/${commitDeployment.id}`,
       READINESS_TIMEOUT,
     )
 
-    console.log(`Waiting for a 200 from: ${url}`)
-    await waitForUrl(url, RESPONSE_TIMEOUT)
+    if (state === 'skipped') {
+      core.setOutput(state, true)
+      console.log('Netlify build was skipped')
+    } else {
+      console.log(`Waiting for a 200 from: ${url}`)
+      await waitForUrl(url, RESPONSE_TIMEOUT)
+    }
   } catch (error) {
     core.setFailed(typeof error === 'string' ? error : error.message)
   }

--- a/src/run/run.js
+++ b/src/run/run.js
@@ -65,10 +65,10 @@ const run = async () => {
     )
 
     if (state === STATE_SKIPPED) {
-      core.setOutput(STATE_SKIPPED, true)
+      core.setOutput(STATE_SKIPPED, 'true')
       console.log('Netlify build was skipped')
     } else {
-      core.setOutput(STATE_SKIPPED, false)
+      core.setOutput(STATE_SKIPPED, 'false')
       console.log(`Waiting for a 200 from: ${url}`)
       await waitForUrl(url, RESPONSE_TIMEOUT)
     }

--- a/src/run/run.js
+++ b/src/run/run.js
@@ -4,6 +4,8 @@ import waitForUrl from '../wait-for-url'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
+const STATE_SKIPPED = 'skipped'
+
 const run = async () => {
   try {
     const netlifyToken = process.env.NETLIFY_TOKEN
@@ -62,10 +64,11 @@ const run = async () => {
       READINESS_TIMEOUT,
     )
 
-    if (state === 'skipped') {
-      core.setOutput(state, true)
+    if (state === STATE_SKIPPED) {
+      core.setOutput(STATE_SKIPPED, true)
       console.log('Netlify build was skipped')
     } else {
+      core.setOutput(STATE_SKIPPED, false)
       console.log(`Waiting for a 200 from: ${url}`)
       await waitForUrl(url, RESPONSE_TIMEOUT)
     }

--- a/src/run/run.test.js
+++ b/src/run/run.test.js
@@ -40,6 +40,24 @@ describe('index', () => {
     expect(core.setFailed).not.toHaveBeenCalled()
   })
 
+  it('succeeds when a deployment is skipped', async () => {
+    setupMockInputs({
+      site_id: 'site-id-skipped',
+    })
+
+    waitForDeployCreation.mockImplementation(() => fakes.deploy)
+    waitForReadiness.mockImplementation(() => 'skipped')
+
+    setGithubContext(fakes.githubContextPullRequestWithSha)
+
+    process.env.NETLIFY_TOKEN = 'token'
+
+    await run()
+
+    expect(core.setOutput).toHaveBeenCalledWith('skipped', true)
+    expect(core.setFailed).not.toHaveBeenCalled()
+  })
+
   it('fails when a promise rejects', async () => {
     setupMockInputs({
       site_id: 'site-id-reject',

--- a/src/run/run.test.js
+++ b/src/run/run.test.js
@@ -33,6 +33,7 @@ describe('index', () => {
     await run()
 
     expect(core.setOutput).toHaveBeenCalledWith('deploy_id', '1')
+    expect(core.setOutput).toHaveBeenCalledWith('skipped', false)
     expect(core.setOutput).toHaveBeenCalledWith(
       'url',
       'https://1--deploy-1.netlify.app',

--- a/src/run/run.test.js
+++ b/src/run/run.test.js
@@ -33,7 +33,7 @@ describe('index', () => {
     await run()
 
     expect(core.setOutput).toHaveBeenCalledWith('deploy_id', '1')
-    expect(core.setOutput).toHaveBeenCalledWith('skipped', false)
+    expect(core.setOutput).toHaveBeenCalledWith('skipped', 'false')
     expect(core.setOutput).toHaveBeenCalledWith(
       'url',
       'https://1--deploy-1.netlify.app',
@@ -55,7 +55,7 @@ describe('index', () => {
 
     await run()
 
-    expect(core.setOutput).toHaveBeenCalledWith('skipped', true)
+    expect(core.setOutput).toHaveBeenCalledWith('skipped', 'true')
     expect(core.setFailed).not.toHaveBeenCalled()
   })
 

--- a/src/wait-for-readiness/fakes.js
+++ b/src/wait-for-readiness/fakes.js
@@ -15,6 +15,11 @@ export const deployReady = {
   state: 'ready',
 }
 
+export const deploySkipped = {
+  ...deployError,
+  error_message: `Failed during stage 'checking build content for changes': Canceled build due to no content change`,
+}
+
 export const deployUnknown = {
   id: 'deploy-unknown',
   state: 'unknown',

--- a/src/wait-for-readiness/wait-for-readiness.test.js
+++ b/src/wait-for-readiness/wait-for-readiness.test.js
@@ -28,6 +28,14 @@ describe('waitForReadiness', () => {
     ).resolves.toEqual()
   })
 
+  it('succeeds when the deployment is `skipped`', async () => {
+    getNetlifyUrl.mockImplementation(() => ({ data: fakes.deploySkipped }))
+
+    await expect(
+      waitForReadiness(url, maxTimeout, intervalIncrement),
+    ).resolves.toEqual('skipped')
+  })
+
   it('fails after reaching the max timeout when the deployment is not ready', async () => {
     const deploy = fakes.deployUnknown
     getNetlifyUrl.mockImplementation(() => ({ data: deploy }))

--- a/tests/workflow-test.sh
+++ b/tests/workflow-test.sh
@@ -1,5 +1,10 @@
 # Perform a full workflow test via `act` using the custom action.
 #
 # Update tests/event.json with a sha from your project deployed to Netlify.
+#
 
-act pull_request -j test -W tests/workflows/ -e tests/event.json --env-file .env.local
+# build action to `dist/`
+docker compose run --rm app build
+
+# run local action using `act`
+act pull_request --job test --workflows tests/workflows/ --eventpath tests/event.json --env-file .env.local

--- a/tests/workflows/test.yml
+++ b/tests/workflows/test.yml
@@ -16,6 +16,12 @@ jobs:
           NETLIFY_TOKEN: ${{ env.NETLIFY_TOKEN }}
         with:
           site_id: ${{ env.NETLIFY_SITE_ID }}
-          deploy_timeout: 30
-          readiness_timeout: 45
-          response_timeout: 5
+          deploy_timeout: 17
+          readiness_timeout: 32
+          response_timeout: 6
+      - name: Echo output deploy_id
+        run: echo ${{ steps.netlify.outputs.deploy_id }}
+      - name: Echo output skipped
+        run: echo ${{ steps.netlify.outputs.skipped }}
+      - name: Echo output url
+        run: echo ${{ steps.netlify.outputs.url }}


### PR DESCRIPTION
# ⚠️ Requires #8 to be merged first

# Overview

Adds support for skipped builds. Netlify will cancel/skip builds under some circumstances. One of these circumstances is a Netlify plugin detecting no content changes and canceling the build. 

This PR:

* Adds a new output named `skipped`
* Detects the Netlify canceled/skipped build
* Sets `skipped` to `'true'` if the build was skipped, output is `'false'` otherwise


