### PR TITLE
[INTERNAL] Add CHANGELOG and Calver versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Calver](https://calver.org) with a version format of `YY.0M.MICRO`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calver](https://calver.org) with a version format of `YY.0M.MICRO`.
+
+## [Unreleased]
+
+### Added
+
+- Fine-grain controls over timeouts from [@hharnisc](https://github.com/hharnisc)
+- Option to filter commits by deploy context [@dnsv](https://github.com/dnsv)
+- Docker Compose configuration for development
+- `eslint` and configuration
+- `prettier` and configuration
+- `@vercel/ncc` to build the action as recommended in the GitHub documentation
+- CircleCI for running linters and tests
+- Dependabot for dependency updates
+- GitHub settings to manage repository
+
+### Changed
+
+- Update action to use `node16`
+- Update package manager from `npm` to `yarn`
+- Update dependencies
+- Remove `node_modules` from repository
+
+---
+
+Forked to `mutations/wait-for-netlify-action` - 2022-02-08
+
+- Last version before fork: 3.2.0 [0855dad](https://github.com/mutations/wait-for-netlify-action/commit/0855dade13fa1445d67907d2b5b2ce470e38c468)
+
+---
+
+Changelog sections:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Fixed` for any bug fixes.
+- `Removed` for now removed features.
+- `Security` in case of vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ jobs:
 
 </details>
 
+## Versioning
+
+This project uses [Calver](https://calver.org) to version the apps and builds. The version format is: `YY.0M.MICRO`.
+
+Examples:
+  - `22.01.1` - First released build in January of 2022
+  - `22.02.15` - Fifteenth release in February of 2022
+  - `22.03-beta` - Beta release of the March 2022 build
+  - `22.03.4-beta` - Beta release of the fourth build in March 2022
+
+Where `Version` is the two-digit year, the zero-padded two-digit month, and a micro segment to indicate the build number for that month. An optional `-MODIFIER` can be used for pre-release, alpha, beta, and the like.
+
 <small>
 This is a heavily-modified fork of [kamranayub/wait-for-netlify-action](https://github.com/kamranayub/wait-for-netlify-action).
 </small>


### PR DESCRIPTION
# Overview

Adds a CHANGELOG using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and a new version scheme based on [Calver](https://calver.org) (Format: `YY.0M.MICRO`).
